### PR TITLE
Add automatic deployment with CircleCI on tagged commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,40 @@
+version: 2
+jobs:
+  deployment:
+    docker:
+      - image: circleci/python:3.8.0-buster
+    steps:
+      - checkout
+      - run:
+          name: make packages
+          command: |
+            # create a source distribution
+            python setup.py sdist
+
+            # create a wheel
+            python setup.py bdist_wheel
+
+      - run:
+          name: upload package
+          environment:
+            TWINE_NON_INTERACTIVE: please
+            TWINE_REPOSITORY_URL: https://pypi.zyper.com/simple/ 
+            # Also depends on TWINE_USERNAME and TWINE_PASSWORD
+          command: |
+            # install twine
+            pip install twine
+
+            # upload
+            twine upload dist/*
+
+ 
+workflows:
+  version: 2
+  deployment-workflow:
+    jobs:
+      - deployment:
+          filters:
+              tags:
+                only: /^v.*/
+              branches:
+                ignore: /.*/


### PR DESCRIPTION
Meant to fix https://github.com/zyperco/zyper-django-api/issues/1091

Needs repo admin to toggle CircleCI here: https://app.circleci.com/projects/project-dashboard/github/zyperco/